### PR TITLE
include: Fix use of <stats.h> -> <stats/stats.h>

### DIFF
--- a/include/nffs/nffs.h
+++ b/include/nffs/nffs.h
@@ -27,7 +27,7 @@
 
 #if __ZEPHYR__
 #include <zephyr/types.h>
-#include <stats.h>
+#include <stats/stats.h>
 #endif
 
 #ifdef __cplusplus


### PR DESCRIPTION
Fix #include <stats.h> as it has been deprecated and
should be #include <stats/stats.h>.

Signed-off-by: Kumar Gala <kumar.gala@linaro.org>